### PR TITLE
feat: ユーザー間の共有のitemsを作成する

### DIFF
--- a/app/components/NavigationTabs.tsx
+++ b/app/components/NavigationTabs.tsx
@@ -4,8 +4,8 @@ export default function NavigationTabs() {
   const location = useLocation();
 
   const tabs = [
-    { name: "マイページ", href: "/", key: "home" },
-    { name: "共有", href: "/share", key: "share" },
+    { name: "my page", href: "/", key: "home" },
+    { name: "share", href: "/share", key: "share" },
   ];
 
   return (

--- a/app/components/NavigationTabs.tsx
+++ b/app/components/NavigationTabs.tsx
@@ -1,0 +1,37 @@
+import { Link, useLocation } from "react-router";
+
+export default function NavigationTabs() {
+  const location = useLocation();
+
+  const tabs = [
+    { name: "マイページ", href: "/", key: "home" },
+    { name: "共有", href: "/share", key: "share" },
+  ];
+
+  return (
+    <div className="border-b border-gray-200 mb-6">
+      <nav className="-mb-px flex space-x-8" aria-label="Tabs">
+        {tabs.map((tab) => {
+          const isActive =
+            (tab.key === "home" && location.pathname === "/") ||
+            (tab.key === "share" && location.pathname === "/share");
+
+          return (
+            <Link
+              key={tab.key}
+              to={tab.href}
+              className={`whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm ${
+                isActive
+                  ? "border-blue-500 text-blue-600"
+                  : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+              }`}
+              aria-current={isActive ? "page" : undefined}
+            >
+              {tab.name}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/app/components/OutlineEditor.tsx
+++ b/app/components/OutlineEditor.tsx
@@ -21,9 +21,10 @@ import { v4 as uuidv4 } from "uuid";
 interface OutlineEditorProps {
   id: string;
   items: Item[];
+  apiPrefix?: string; // オプショナルなAPIプレフィックス
 }
 
-function OutlineEditor({ id, items }: OutlineEditorProps) {
+function OutlineEditor({ id, items, apiPrefix = "" }: OutlineEditorProps) {
   // Stateの型を指定
   const [title, _setTitle] = useState<string>("");
   const [itemList, setItemList] = useState<Item[]>(items);
@@ -56,7 +57,7 @@ function OutlineEditor({ id, items }: OutlineEditorProps) {
           { items: itemList },
           {
             method: "POST",
-            action: `/update/${id}`,
+            action: `${apiPrefix}/update/${id}`,
             encType: "application/json",
           },
         );

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -2,6 +2,8 @@ import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
 export default [
   index("routes/home.tsx"),
+  route("share", "routes/share.tsx"),
   route(":itemId", "routes/item.tsx"),
   route("update/:id", "routes/update.ts"),
+  route("share/update/:id", "routes/share/update.$id.ts"),
 ] satisfies RouteConfig;

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,4 +1,5 @@
 import OutlineEditor from "../components/OutlineEditor.tsx";
+import NavigationTabs from "../components/NavigationTabs.tsx";
 import type { Item } from "../../domain/item";
 import { newItem } from "../../domain/logic";
 import { getItemsFromKV } from "../services/kv.server.ts";
@@ -50,6 +51,7 @@ export default function Index() {
 
   return (
     <div className="max-w-3xl mx-auto pt-4 pb-28 px-8">
+      <NavigationTabs />
       <OutlineEditor id="root" items={items} />
     </div>
   );

--- a/app/routes/share.tsx
+++ b/app/routes/share.tsx
@@ -16,27 +16,33 @@ export async function loader({
   context,
   request,
 }: LoaderFunctionArgs): Promise<LoaderData> {
-  const env = context.cloudflare.env;
+  try {
+    const env = context.cloudflare.env;
 
-  // 認証チェック - ユーザー ID を取得
-  const useridres = await getUserEmail(env, request);
-  if (useridres.isErr()) {
-    throw new Response("Unauthorized", { status: 401 });
+    // 認証チェック - ユーザー ID を取得
+    const useridres = await getUserEmail(env, request);
+    if (useridres.isErr()) {
+      console.error("認証エラー:", useridres.error.message);
+      throw new Response("Unauthorized", { status: 401 });
+    }
+
+    // 共有データは固定のuserIdを使用
+    const userId = "share";
+
+    // KV からアイテムを取得、なければ新しいアイテムを作成
+    let items = await getItemsFromKV(env.ITEMS_KV, userId);
+    if (items.length === 0) {
+      items = [newItem(uuidv4())];
+    }
+
+    return {
+      items,
+      userId,
+    };
+  } catch (error) {
+    console.error("Share page loader error:", error);
+    throw new Response("Internal Server Error", { status: 500 });
   }
-
-  // 共有データは固定のuserIdを使用
-  const userId = "share";
-
-  // KV からアイテムを取得、なければ新しいアイテムを作成
-  let items = await getItemsFromKV(env.ITEMS_KV, userId);
-  if (items.length === 0) {
-    items = [newItem(uuidv4())];
-  }
-
-  return {
-    items,
-    userId,
-  };
 }
 
 export default function Share() {

--- a/app/routes/share.tsx
+++ b/app/routes/share.tsx
@@ -1,7 +1,3 @@
-import OutlineEditor from "../components/OutlineEditor.tsx";
-import type { Item } from "../../domain/item";
-import { newItem } from "../../domain/logic";
-import { getItemsFromKV } from "../services/kv.server.ts";
 import type { LoaderFunctionArgs } from "react-router";
 import { useLoaderData } from "react-router";
 import { v4 as uuidv4 } from "uuid";

--- a/app/routes/share.tsx
+++ b/app/routes/share.tsx
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 import type { Item } from "../../domain/item";
 import { newItem } from "../../domain/logic";
 import OutlineEditor from "../components/OutlineEditor.tsx";
+import NavigationTabs from "../components/NavigationTabs.tsx";
 import { getItemsFromKV } from "../services/kv.server.ts";
 import { getUserEmail } from "../util.server.ts";
 
@@ -50,6 +51,7 @@ export default function Share() {
 
   return (
     <div className="max-w-3xl mx-auto pt-4 pb-28 px-8">
+      <NavigationTabs />
       <OutlineEditor id="root" items={items} apiPrefix="/share" />
     </div>
   );

--- a/app/routes/share.tsx
+++ b/app/routes/share.tsx
@@ -1,0 +1,50 @@
+import OutlineEditor from "../components/OutlineEditor.tsx";
+import type { Item } from "../../domain/item";
+import { newItem } from "../../domain/logic";
+import { getItemsFromKV } from "../services/kv.server.ts";
+import type { LoaderFunctionArgs } from "react-router";
+import { useLoaderData } from "react-router";
+import { v4 as uuidv4 } from "uuid";
+import { getUserEmail } from "../util.server.ts";
+
+interface LoaderData {
+  items: Item[];
+  userId: string;
+}
+
+export async function loader({
+  context,
+  request,
+}: LoaderFunctionArgs): Promise<LoaderData> {
+  const env = context.cloudflare.env;
+
+  // 認証チェック - ユーザー ID を取得
+  const useridres = await getUserEmail(env, request);
+  if (useridres.isErr()) {
+    throw new Response("Unauthorized", { status: 401 });
+  }
+
+  // 共有データは固定のuserIdを使用
+  const userId = "share";
+
+  // KV からアイテムを取得、なければ新しいアイテムを作成
+  let items = await getItemsFromKV(env.ITEMS_KV, userId);
+  if (items.length === 0) {
+    items = [newItem(uuidv4())];
+  }
+
+  return {
+    items,
+    userId,
+  };
+}
+
+export default function Share() {
+  const { items } = useLoaderData<LoaderData>();
+
+  return (
+    <div className="max-w-3xl mx-auto pt-4 pb-28 px-8">
+      <OutlineEditor id="root" items={items} apiPrefix="/share" />
+    </div>
+  );
+}

--- a/app/routes/share.tsx
+++ b/app/routes/share.tsx
@@ -1,6 +1,10 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { useLoaderData } from "react-router";
 import { v4 as uuidv4 } from "uuid";
+import type { Item } from "../../domain/item";
+import { newItem } from "../../domain/logic";
+import OutlineEditor from "../components/OutlineEditor.tsx";
+import { getItemsFromKV } from "../services/kv.server.ts";
 import { getUserEmail } from "../util.server.ts";
 
 interface LoaderData {

--- a/app/routes/share/update.$id.ts
+++ b/app/routes/share/update.$id.ts
@@ -1,0 +1,81 @@
+import type { ActionFunctionArgs } from "react-router";
+import { z } from "zod";
+import type { Item } from "../../../domain/item";
+import { saveItemsToKV } from "../../services/kv.server";
+import { getUserEmail } from "../../util.server";
+
+// アイテムのスキーマ定義
+const ItemSchema: z.ZodType<Item> = z.lazy(() =>
+  z.object({
+    id: z.string(),
+    symbol: z.enum([
+      "dot",
+      "naraba",
+      "therefore",
+      "because",
+      "equal",
+      "notEqual",
+    ]),
+    text: z.string(),
+    children: z.array(ItemSchema),
+    isExpanded: z.boolean(),
+  }),
+);
+
+// リクエストボディのスキーマ
+const UpsertItemsSchema = z.object({
+  items: z.array(ItemSchema),
+});
+
+export async function action({ request, context, params }: ActionFunctionArgs) {
+  const env = context.cloudflare.env;
+
+  // 認証チェック - ユーザー ID を取得
+  const useridres = await getUserEmail(env, request);
+  if (useridres.isErr()) {
+    throw new Response("Unauthorized", { status: 401 });
+  }
+
+  // 共有データは固定のuserIdを使用
+  const userId = "share";
+
+  // POSTメソッドのみ受け付ける
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const id = params.id;
+  if (!id) {
+    return Response.json({ error: "Item ID is required" }, { status: 400 });
+  }
+
+  try {
+    // リクエストボディをパース
+    const body = await request.json();
+
+    // バリデーション
+    const validationResult = UpsertItemsSchema.safeParse(body);
+    if (!validationResult.success) {
+      return Response.json(
+        {
+          error: "Invalid request body",
+          details: validationResult.error.flatten(),
+        },
+        { status: 400 },
+      );
+    }
+
+    const { items } = validationResult.data;
+
+    // KVに保存（共有データとして）
+    await saveItemsToKV(env.ITEMS_KV, userId, id, items);
+
+    // 成功レスポンス
+    return Response.json({
+      message: "Items saved successfully",
+    });
+  } catch (error) {
+    console.error("Error upserting items:", error);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/util.server.ts
+++ b/app/util.server.ts
@@ -1,9 +1,12 @@
 import { errAsync, okAsync, type ResultAsync } from "neverthrow";
 
-export const getUserEmail = (env: Env, request: Request): ResultAsync<string, Error> => {
+export const getUserEmail = (
+  env: Env,
+  request: Request,
+): ResultAsync<string, Error> => {
   // モック環境では固定のメールアドレスを返す
   if (env.AUTH_MOCK) {
-    return okAsync("mock-user")
+    return okAsync("mock-user");
   }
 
   const cookieHeader = request.headers.get("Cookie") || "";


### PR DESCRIPTION
## 概要

全てのユーザーで共通の items を表示・編集できる共有機能を実装しました。

## 変更内容

- `/share` ルートを追加し、全ユーザーで共通のitemsを表示・編集可能に
- `/share/update/:id` APIエンドポイントを追加し、共有データ用の更新処理を実装
- OutlineEditorコンポーネントにapiPrefixプロパティを追加し、エンドポイントを切り替え可能に
- 共有データはuserId = "share"で保存され、認証されたユーザーのみアクセス可能

## テスト計画

- [ ] `/share` ページにアクセスできることを確認
- [ ] 認証なしでアクセスすると401エラーになることを確認
- [ ] 共有データの編集が全ユーザーで反映されることを確認
- [ ] 既存のユーザー個別機能に影響がないことを確認

Closes ##1

Generated with [Claude Code](https://claude.ai/code)